### PR TITLE
docs: fix simple typo, grammer -> grammar

### DIFF
--- a/js2coffee/jsparser.py
+++ b/js2coffee/jsparser.py
@@ -974,7 +974,7 @@ def Expression(t, x, stop=None):
             elif tt == LEFT_BRACKET:
                 if t.scanOperand:
                     # Array initializer. Parse using recursive descent, as the
-                    # sub-grammer here is not an operator grammar.
+                    # sub-grammar here is not an operator grammar.
                     n = Node(t, ARRAY_INIT)
                     while True:
                         tt = t.peek()


### PR DESCRIPTION
There is a small typo in js2coffee/jsparser.py.

Should read `grammar` rather than `grammer`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md